### PR TITLE
Update import to assert, fixed output file logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ import { getDefaultProvider, Wallet, Contract } from "ethers";
 import { writeFile } from "fs/promises";
 
 // ABI
-import abi from "./abi.json" assert { type: "json" };
-import erc20 from "./erc20.json" assert { type: "json" };
+import abi from "./abi.json" with { type: "json" };
+import erc20 from "./erc20.json" with { type: "json" };
 
 // Env
 dotenv.config();

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ await writeFile(`wallets/wallets-${id}.csv`, walletsCSV.join("\n"));
 console.log({
   filesCreated:{
     json: `wallets/wallets-${id}.json`,
-    json: `wallets/wallets-${id}.csv`
+    csv: `wallets/wallets-${id}.csv`
   }
 })
 // process.exit(0);


### PR DESCRIPTION
### Changes

- In newer Node versions the 'wait' keyword will be used instead of 'assert'. See: https://github.com/tc39/proposal-import-attributes (was not able to run it with Node v22.7.0 with 'assert')
- Fixed logging of the files to include 'csv' key instead of a duplicate 'json' key.

